### PR TITLE
fix canvas initial load size "jump"

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -19,7 +19,12 @@ export const Canvas = () => {
     <div className='absolute inset-4 overflow-y-auto'>
       <div className='absolute inset-0 flex justify-center items-center'>
         <div className='relative flex items-center w-full h-full max-w-[500px] max-h-[500px]'>
-          <canvas ref={canvasRef} className='drop-shadow-xl absolute max-h-full max-w-full bg-neutral-900' />
+          <canvas
+            width={DEFAULT_WIDTH}
+            height={DEFAULT_HEIGHT}
+            ref={canvasRef}
+            className='drop-shadow-xl absolute max-h-full max-w-full bg-neutral-900'
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Changes

<!-- [Linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) can be used for issues -->

- fixes canvas size "jump" during initial load (from default size 150x300 to 1024x1024)
