### PR TITLE
render: remove redundant `width`, `height` props

### DIFF
--- a/src/context/RendererContext.tsx
+++ b/src/context/RendererContext.tsx
@@ -18,11 +18,8 @@ export const RendererContextProvider: React.FC<RendererContextProviderProps> = (
 
   React.useEffect(() => {
     const canvas = canvasRef.current as HTMLCanvasElement
-    const { width, height } = canvas
     new Renderer(
       canvas,
-      width,
-      height,
       (r: Renderer) => setRenderer(r),
     )
   }, [canvasRef])

--- a/src/graphics/Renderer.ts
+++ b/src/graphics/Renderer.ts
@@ -11,8 +11,6 @@ import {
 export class Renderer {
   private ready: boolean = false
   private canvas: HTMLCanvasElement
-  private width: number
-  private height: number
   private offscreenSupported: boolean
   private ctx?: CanvasRenderingContext2D
   private offscreenCanvas?: OffscreenCanvas
@@ -20,13 +18,9 @@ export class Renderer {
 
   constructor(
     canvas: HTMLCanvasElement,
-    width: number,
-    height: number,
     onReady: (renderer: Renderer) => void,
   ) {
     this.canvas = canvas
-    this.width = width
-    this.height = height
     this.offscreenSupported = OffscreenCanvasFeature.isSupported()
 
     this.init(onReady)
@@ -69,13 +63,7 @@ export class Renderer {
       if (!this.ctx) {
         throw new Error('Context wasn\'t not set')
       }
-      render(
-        this.ctx,
-        this.width,
-        this.height,
-        options,
-        onComplete,
-      )
+      render(this.ctx, options, onComplete)
     } else {
       if (!this.offscreenCanvas) {
         throw new Error('OffscreenCanvas wasn\'t set')
@@ -86,8 +74,6 @@ export class Renderer {
 
       const msg: RendererWorkerRenderMessage = {
         type: RendererWorkerMessageType.render,
-        width: this.width,
-        height: this.height,
         options,
       }
 

--- a/src/graphics/helpers/helpers/renderMatrix.ts
+++ b/src/graphics/helpers/helpers/renderMatrix.ts
@@ -2,8 +2,6 @@ import { randomInt } from '@/utils/random'
 
 export const renderMatrix = (
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
-  width: number,
-  height: number,
   spacing: number,
   tileSize: number,
   brightnessMin: number,
@@ -22,11 +20,11 @@ export const renderMatrix = (
 
   const cols = randomInt(colsMin, colsMax)
   const rows = randomInt(rowsMin, rowsMax)
-  const matrixWidth = cols * tileSize + spacing * (cols - 1)
-  const matrixHeight = rows * tileSize + spacing * (rows - 1)
+  const width = cols * tileSize + spacing * (cols - 1)
+  const height = rows * tileSize + spacing * (rows - 1)
 
-  const x0 = randomInt(0, width - matrixWidth - 1)
-  const y0 = randomInt(0, height - matrixHeight - 1)
+  const x0 = randomInt(0, ctx.canvas.width - width - 1)
+  const y0 = randomInt(0, ctx.canvas.height - height - 1)
 
   let x = x0
   let y = y0

--- a/src/graphics/helpers/helpers/renderRect.ts
+++ b/src/graphics/helpers/helpers/renderRect.ts
@@ -2,12 +2,10 @@ import { randomInt } from '@/utils/random'
 
 export const renderRect = (
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
-  width: number,
-  height: number,
-  rectMinWidth: number,
-  rectMaxWidth: number,
-  rectMinHeight: number,
-  rectMaxHeight: number,
+  minWidth: number,
+  maxWidth: number,
+  minHeight: number,
+  maxHeight: number,
   brightnessMin: number,
   brightnessMax: number,
   alphaMin: number,
@@ -18,13 +16,13 @@ export const renderRect = (
 
   ctx.fillStyle = `rgba(${brightness}, ${brightness}, ${brightness}, ${alpha})`
 
-  const rectWidth = randomInt(rectMinWidth, rectMaxWidth)
-  const rectHeight = randomInt(rectMinHeight, rectMaxHeight)
+  const width = randomInt(minWidth, maxWidth)
+  const height = randomInt(minHeight, maxHeight)
 
   ctx.fillRect(
-    randomInt(0, width - rectWidth - 1),
-    randomInt(0, height - rectHeight - 1),
-    rectWidth,
-    rectHeight,
+    randomInt(0, ctx.canvas.width - width - 1),
+    randomInt(0, ctx.canvas.height - height - 1),
+    width,
+    height,
   )
 }

--- a/src/graphics/helpers/render.ts
+++ b/src/graphics/helpers/render.ts
@@ -5,8 +5,6 @@ import { renderMatrix, renderRect } from './helpers'
 
 export const render = (
   ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
-  width: number,
-  height: number,
   {
     iterations,
     iterationsPerFrame = 50,
@@ -28,6 +26,8 @@ export const render = (
   }: RenderOptions,
   onComplete: () => void,
 ) => {
+  const { width, height } = ctx.canvas
+
   ctx.fillStyle = `rgb(${backgroundBrightness}, ${backgroundBrightness}, ${backgroundBrightness})`
   ctx.fillRect(0, 0, width, height)
 
@@ -48,8 +48,6 @@ export const render = (
       if (randomBool()) {
         renderRect(
           ctx,
-          width,
-          height,
           rectMinWidth,
           rectMaxWidth,
           rectMinHeight,
@@ -62,8 +60,6 @@ export const render = (
       } else {
         renderMatrix(
           ctx,
-          width,
-          height,
           matrixSpacing,
           matrixTileSize,
           matrixBrightnessMin,

--- a/src/graphics/workers/renderer/RendererWorker.ts
+++ b/src/graphics/workers/renderer/RendererWorker.ts
@@ -22,11 +22,7 @@ self.onmessage = (event) => {
   }
 
   if (event.data.type === RendererWorkerMessageType.render) {
-    const {
-      width,
-      height,
-      options,
-    } = event.data
+    const { options } = event.data
 
     if (!offscreenCanvas) {
       throw new Error('offscreenCanvas wasn\'t initialized')
@@ -38,12 +34,6 @@ self.onmessage = (event) => {
       throw new Error('Cannot get 2d context of the offscreen canvas')
     }
 
-    render(
-      ctx,
-      width,
-      height,
-      options,
-      onCompleted,
-    )
+    render(ctx, options, onCompleted)
   }
 }

--- a/src/graphics/workers/renderer/types.ts
+++ b/src/graphics/workers/renderer/types.ts
@@ -13,8 +13,6 @@ export type RendererWorkerInitializeMessage = {
 
 export type RendererWorkerRenderMessage = {
   type: RendererWorkerMessageType.render
-  width: number,
-  height: number,
   options: RenderOptions,
 }
 


### PR DESCRIPTION
## Changes

<!-- [Linking syntax](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) can be used for issues -->

- resolves: https://github.com/satelllte/displacement/issues/97
